### PR TITLE
Refactor to support type declarion parsing

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.3.0] - 2022-04-14
+
+### Added
+
+- `type` now can also be sorted on top of `interface`. Use `sortTypes` setting to turn it off.
+
 ## [0.2.2] - 2022-04-12
 
 ### Security

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - `type` now can also be sorted on top of `interface`. Use `sortTypes` setting to turn it off.
 
+### Changed
+
+- Updated bundled `typescript` version to 4.6.3.
+
 ## [0.2.2] - 2022-04-12
 
 ### Security

--- a/README.md
+++ b/README.md
@@ -17,3 +17,4 @@ This extension contributes the following settings:
 - `tsInterfaceSorter.emptyLineBetweenProperties`: Controls whether an empty line should be inserted between properties.
 - `tsInterfaceSorter.sortByCapitalLetterFirst`: Controls whether properties started with capital letters should be sorted first separately before lower case ones.
 - `tsInterfaceSorter.sortByRequiredElementFirst`: Controls whether required property should be sorted first. If turned on, takes precedence over `sortByCapitalLetterFirst` option.
+- `tsInterfaceSorter.sortTypes`: When on, sort `type` as well as `interface`.

--- a/jest.config.js
+++ b/jest.config.js
@@ -1,4 +1,11 @@
 module.exports = {
-  preset: 'ts-jest',
-  testEnvironment: 'node'
+  preset: "ts-jest",
+  testEnvironment: "node",
+
+  globals: {
+    "ts-jest": {
+      // Disable type checking in test
+      diagnostics: false,
+    },
+  },
 };

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,15 +1,15 @@
 {
   "name": "ts-interface-sorter",
-  "version": "0.2.2",
+  "version": "0.3.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "ts-interface-sorter",
-      "version": "0.2.2",
+      "version": "0.3.0",
       "license": "MIT",
       "dependencies": {
-        "typescript": "^4.1.3"
+        "typescript": "^4.6.3"
       },
       "devDependencies": {
         "@types/jest": "^27.0.0",
@@ -5027,9 +5027,9 @@
       }
     },
     "node_modules/typescript": {
-      "version": "4.2.4",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.2.4.tgz",
-      "integrity": "sha512-V+evlYHZnQkaz8TRBuxTA92yZBPotr5H+WhQ7bD3hZUndx5tGOa1fuCgeSjxAzM1RiN5IzvadIXTVefuuwZCRg==",
+      "version": "4.6.3",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.6.3.tgz",
+      "integrity": "sha512-yNIatDa5iaofVozS/uQJEl3JRWLKKGJKh6Yaiv0GLGSuhpFJe7P3SbHZ8/yjAHRQwKRoA6YZqlfjXWmVzoVSMw==",
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"
@@ -9146,9 +9146,9 @@
       }
     },
     "typescript": {
-      "version": "4.2.4",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.2.4.tgz",
-      "integrity": "sha512-V+evlYHZnQkaz8TRBuxTA92yZBPotr5H+WhQ7bD3hZUndx5tGOa1fuCgeSjxAzM1RiN5IzvadIXTVefuuwZCRg=="
+      "version": "4.6.3",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.6.3.tgz",
+      "integrity": "sha512-yNIatDa5iaofVozS/uQJEl3JRWLKKGJKh6Yaiv0GLGSuhpFJe7P3SbHZ8/yjAHRQwKRoA6YZqlfjXWmVzoVSMw=="
     },
     "universalify": {
       "version": "0.1.2",

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "ts-interface-sorter",
   "displayName": "TypeScript Interface Sorter",
   "description": "Sort TypeScript interface properties",
-  "version": "0.2.2",
+  "version": "0.3.0",
   "engines": {
     "vscode": "^1.50.0"
   },
@@ -22,7 +22,7 @@
     "vsce:publish:bump": "vsce publish patch"
   },
   "dependencies": {
-    "typescript": "^4.1.3"
+    "typescript": "^4.6.3"
   },
   "devDependencies": {
     "@types/jest": "^27.0.0",

--- a/package.json
+++ b/package.json
@@ -69,6 +69,11 @@
           "type": "boolean",
           "default": false,
           "description": "Controls whether required property should be sorted first. If turned on, takes precedence over sortByCapitalLetterFirst option."
+        },
+        "tsInterfaceSorter.sortTypes": {
+          "type": "boolean",
+          "default": true,
+          "description": "When on, sort `type` as well as `interface`."
         }
       }
     }

--- a/src/components/configurator.ts
+++ b/src/components/configurator.ts
@@ -3,7 +3,19 @@ export interface IInterfaceSorterConfiguration {
   lineBetweenMembers?: boolean;
   sortByCapitalLetterFirst?: boolean;
   sortByRequiredElementFirst?: boolean;
+  sortTypes?: boolean;
 }
+
+/**
+ * Default configs.
+ */
+export const defaultConfig: IInterfaceSorterConfiguration = {
+  lineBetweenMembers: true,
+  indentSpace: 2,
+  sortByCapitalLetterFirst: false,
+  sortByRequiredElementFirst: false,
+  sortTypes: true
+};
 
 export type InterfaceSorterConfigurationKeys =
   keyof IInterfaceSorterConfiguration;

--- a/src/components/parser.ts
+++ b/src/components/parser.ts
@@ -1,5 +1,6 @@
 import * as fs from "fs";
 import * as ts from "typescript";
+import { defaultConfig, IConfigurator, IInterfaceSorterConfiguration, SimpleConfigurator } from "./configurator";
 
 export interface IComment {
   text: string;
@@ -45,6 +46,14 @@ export interface ITsParser {
 }
 
 export class SimpleTsParser implements ITsParser {
+  private configurator: IConfigurator<IInterfaceSorterConfiguration>;
+
+  public constructor(
+    configurator: IConfigurator<IInterfaceSorterConfiguration>
+  ) {
+    this.configurator = configurator;
+  }
+
   public parseTypeNodes(
     fullFilePath: string,
     _sourceText?: string | undefined
@@ -95,6 +104,11 @@ export class SimpleTsParser implements ITsParser {
         break;
       }
       case ts.SyntaxKind.TypeAliasDeclaration: {
+        const sortTypes = this.configurator.getValue("sortTypes") as boolean;
+        if (!sortTypes) {
+          break;
+        }
+
         const typeNode = node as ts.TypeAliasDeclaration;
         const lines = this.getCodeLineNumbers(node, sourceFile);
         if (typeNode.type.kind === ts.SyntaxKind.TypeLiteral) {

--- a/src/components/parser.ts
+++ b/src/components/parser.ts
@@ -105,6 +105,7 @@ export class SimpleTsParser implements ITsParser {
       }
       case ts.SyntaxKind.TypeAliasDeclaration: {
         const sortTypes = this.configurator.getValue("sortTypes") as boolean;
+        // Only parse `type` when settings is true
         if (!sortTypes) {
           break;
         }

--- a/src/components/parser.ts
+++ b/src/components/parser.ts
@@ -89,7 +89,7 @@ export class SimpleTsParser implements ITsParser {
           start: lines.start,
           end: lines.end,
           comments: this.getComments(node, sourceFileText),
-          members: this.delintInterfaceElements(interfaceNode, sourceFile, sourceFileText)
+          members: this.getMembers(interfaceNode, sourceFile, sourceFileText)
         };
         typeNodes.push(delintedInterface);
         break;
@@ -98,7 +98,7 @@ export class SimpleTsParser implements ITsParser {
         const typeNode = node as ts.TypeAliasDeclaration;
         const lines = this.getCodeLineNumbers(node, sourceFile);
         if (typeNode.type.kind === ts.SyntaxKind.TypeLiteral) {
-          const members = this.delintTypeElements(typeNode.type as ts.TypeLiteralNode, sourceFile, sourceFileText);
+          const members = this.getMembers(typeNode.type as ts.TypeLiteralNode, sourceFile, sourceFileText);
           const delintedInterface: ITsTypeLiteralNode = {
             declaration: typeNode,
             start: lines.start,
@@ -147,29 +147,11 @@ export class SimpleTsParser implements ITsParser {
     return { start, end };
   }
 
-  private delintInterfaceElements(
-    node: ts.InterfaceDeclaration,
-    sourceFile: ts.SourceFile,
-    sourceFileText: string
-  ): ITsTypeMemberNode[] {
-    return node.members.map(x => {
-      const lines = this.getCodeLineNumbers(x, sourceFile);
-      const comments = this.getComments(x, sourceFileText);
-      return {
-        element: x,
-        text: x.getText(sourceFile).trim(),
-        start: lines.start,
-        end: lines.end,
-        comments
-      };
-    });
-  }
-
-  private delintTypeElements(
-    node: ts.TypeLiteralNode,
-    sourceFile: ts.SourceFile,
-    sourceFileText: string
-  ): ITsTypeMemberNode[] {
+  private getMembers<T extends { readonly members: ts.NodeArray<ts.TypeElement>; }>
+    (
+      node: T,
+      sourceFile: ts.SourceFile,
+      sourceFileText: string) {
     return node.members.map(x => {
       const lines = this.getCodeLineNumbers(x, sourceFile);
       const comments = this.getComments(x, sourceFileText);

--- a/src/components/parser.ts
+++ b/src/components/parser.ts
@@ -18,28 +18,37 @@ export interface ITsNode {
   comments: IComments;
 }
 
-export interface ITsInterfaceNode extends ITsNode {
-  declaration: ts.InterfaceDeclaration;
-  members: Array<ITsInterfaceMemberNode>;
+export interface ITsNodeWithMembers extends ITsNode {
+  members: Array<ITsTypeMemberNode>;
 }
 
-export interface ITsInterfaceMemberNode extends ITsNode {
+export interface ITsInterfaceNode extends ITsNodeWithMembers {
+  declaration: ts.InterfaceDeclaration;
+}
+
+export interface ITsTypeLiteralNode extends ITsNodeWithMembers {
+  declaration: ts.TypeAliasDeclaration;
+}
+
+export type ITypeNode = ITsInterfaceNode | ITsTypeLiteralNode;
+
+export interface ITsTypeMemberNode extends ITsNode {
   element: ts.TypeElement;
   text: string;
 }
 
 export interface ITsParser {
-  parseInterface(
+  parseTypeNodes(
     fullFilePath: string,
     sourceFileText?: string
-  ): { nodes: ITsInterfaceNode[]; sourceFile: ts.SourceFile | null };
+  ): { nodes: ITypeNode[]; sourceFile: ts.SourceFile | null };
 }
 
 export class SimpleTsParser implements ITsParser {
-  public parseInterface(
+  public parseTypeNodes(
     fullFilePath: string,
     _sourceText?: string | undefined
-  ): { nodes: ITsInterfaceNode[]; sourceFile: ts.SourceFile | null } {
+  ): { nodes: ITypeNode[]; sourceFile: ts.SourceFile | null } {
     if (_sourceText !== null && _sourceText !== undefined && _sourceText.trim() === "") {
       return { nodes: [], sourceFile: null };
     }
@@ -58,21 +67,21 @@ export class SimpleTsParser implements ITsParser {
   private delintFile(
     sourceFile: ts.SourceFile,
     sourceText?: string
-  ): { interfaces: ITsInterfaceNode[] } {
+  ): { interfaces: ITypeNode[] } {
     const sourceFileText = sourceText || sourceFile.getText();
 
-    return { interfaces: this.delintInterfaces(sourceFile, sourceFile, sourceFileText) };
+    return { interfaces: this.delintTypeNodes(sourceFile, sourceFile, sourceFileText) };
   }
 
-  private delintInterfaces(
+  private delintTypeNodes(
     node: ts.Node,
     sourceFile: ts.SourceFile,
     sourceFileText: string
-  ): ITsInterfaceNode[] {
-    const interfaceNodes: ITsInterfaceNode[] = [];
+  ): ITypeNode[] {
+    const typeNodes: ITypeNode[] = [];
 
     switch (node.kind) {
-      case ts.SyntaxKind.InterfaceDeclaration:
+      case ts.SyntaxKind.InterfaceDeclaration: {
         const interfaceNode = node as ts.InterfaceDeclaration;
         const lines = this.getCodeLineNumbers(node, sourceFile);
         const delintedInterface: ITsInterfaceNode = {
@@ -82,17 +91,34 @@ export class SimpleTsParser implements ITsParser {
           comments: this.getComments(node, sourceFileText),
           members: this.delintInterfaceElements(interfaceNode, sourceFile, sourceFileText)
         };
-        interfaceNodes.push(delintedInterface);
+        typeNodes.push(delintedInterface);
         break;
+      }
+      case ts.SyntaxKind.TypeAliasDeclaration: {
+        const typeNode = node as ts.TypeAliasDeclaration;
+        const lines = this.getCodeLineNumbers(node, sourceFile);
+        if (typeNode.type.kind === ts.SyntaxKind.TypeLiteral) {
+          const members = this.delintTypeElements(typeNode.type as ts.TypeLiteralNode, sourceFile, sourceFileText);
+          const delintedInterface: ITsTypeLiteralNode = {
+            declaration: typeNode,
+            start: lines.start,
+            end: lines.end,
+            comments: this.getComments(node, sourceFileText),
+            members
+          };
+          typeNodes.push(delintedInterface);
+        }
+        break;
+      }
       default:
         break;
     }
 
     ts.forEachChild(node, node => {
-      interfaceNodes.push(...this.delintInterfaces(node, sourceFile, sourceFileText));
+      typeNodes.push(...this.delintTypeNodes(node, sourceFile, sourceFileText));
     });
 
-    return interfaceNodes;
+    return typeNodes;
   }
 
   private getComments(node: ts.Node, sourceFileText: string): IComments {
@@ -125,7 +151,25 @@ export class SimpleTsParser implements ITsParser {
     node: ts.InterfaceDeclaration,
     sourceFile: ts.SourceFile,
     sourceFileText: string
-  ): ITsInterfaceMemberNode[] {
+  ): ITsTypeMemberNode[] {
+    return node.members.map(x => {
+      const lines = this.getCodeLineNumbers(x, sourceFile);
+      const comments = this.getComments(x, sourceFileText);
+      return {
+        element: x,
+        text: x.getText(sourceFile).trim(),
+        start: lines.start,
+        end: lines.end,
+        comments
+      };
+    });
+  }
+
+  private delintTypeElements(
+    node: ts.TypeLiteralNode,
+    sourceFile: ts.SourceFile,
+    sourceFileText: string
+  ): ITsTypeMemberNode[] {
     return node.members.map(x => {
       const lines = this.getCodeLineNumbers(x, sourceFile);
       const comments = this.getComments(x, sourceFileText);

--- a/src/components/sorter.ts
+++ b/src/components/sorter.ts
@@ -3,7 +3,7 @@ import * as ts from "typescript";
 import { ITsInterfaceNode, ITsNodeWithMembers, ITsTypeMemberNode, ITypeNode } from "./parser";
 import { IConfigurator, IInterfaceSorterConfiguration } from "./configurator";
 
-export interface ISortedMemberElements {
+export interface ISortedElements {
   textToReplace: string;
   rangeToRemove: ts.TextRange;
 }
@@ -11,7 +11,7 @@ export interface ISortedMemberElements {
 export interface ITsSorter {
   sortGenericTypeElements(
     typeNodes: ITsNodeWithMembers[]
-  ): ISortedMemberElements[];
+  ): ISortedElements[];
 }
 
 export type MemberCompareFunction = (
@@ -30,8 +30,8 @@ export class SimpleTsSorter implements ITsSorter {
 
   public sortGenericTypeElements(
     genericTypeElements: ITsNodeWithMembers[]
-  ): ISortedMemberElements[] {
-    const sortedInterfaceElements: ISortedMemberElements[] = [];
+  ): ISortedElements[] {
+    const sortedInterfaceElements: ISortedElements[] = [];
 
     for (let i = 0; i < genericTypeElements.length; i++) {
       const elementWithMembers = genericTypeElements[i];

--- a/src/sort-interface-extension.ts
+++ b/src/sort-interface-extension.ts
@@ -16,40 +16,25 @@ import {
   SimpleConfigurator,
   IConfiguration,
   IInterfaceSorterConfiguration,
+  defaultConfig,
 } from "./components/configurator";
 
 const EXTENSION_IDENTIFIER = "tsInterfaceSorter";
 
 export class SortInterfaceExtension {
-  /**
-   * Default configs. Don't forget to update `updateFromWorkspaceConfig` override as well.
-   * Otherwise settings change will not be taken into account.
-   */
-  private defaultConfig: IInterfaceSorterConfiguration = {
-    lineBetweenMembers: true,
-    indentSpace: 2,
-    sortByCapitalLetterFirst: false,
-    sortByRequiredElementFirst: false,
-  };
 
   private config: IConfiguration<IInterfaceSorterConfiguration> = {
-    default: this.defaultConfig,
+    default: defaultConfig,
   };
   private configurator: IConfigurator<IInterfaceSorterConfiguration> =
     new SimpleConfigurator(this.config);
-  private parser: ITsParser = new SimpleTsParser();
+  private parser: ITsParser = new SimpleTsParser(this.configurator);
   private sorter: ITsSorter = new SimpleTsSorter(this.configurator);
 
   public updateFromWorkspaceConfig() {
     const fullConfig = workspace.getConfiguration(EXTENSION_IDENTIFIER);
 
-    const override = {
-      lineBetweenMembers: fullConfig.emptyLineBetweenProperties,
-      sortByCapitalLetterFirst: fullConfig.sortByCapitalLetterFirst,
-      sortByRequiredElementFirst: fullConfig.sortByRequiredElementFirst,
-    };
-
-    this.configurator.setOverride(override);
+    this.configurator.setOverride(fullConfig as any);
   }
 
   public sortActiveWindowInterfaceMembers(event?: TextDocumentChangeEvent) {

--- a/src/sort-interface-extension.ts
+++ b/src/sort-interface-extension.ts
@@ -59,13 +59,13 @@ export class SortInterfaceExtension {
           ? event.document
           : window.activeTextEditor.document;
         const text = doc.getText();
-        const { nodes, sourceFile } = this.parser.parseInterface(
+        const { nodes, sourceFile } = this.parser.parseTypeNodes(
           doc.uri.fsPath,
           text
         );
 
         if (nodes.length > 0 && sourceFile) {
-          const sortedInterface = this.sorter.sortInterfaceElements(nodes);
+          const sortedInterface = this.sorter.sortGenericTypeElements(nodes);
 
           if (event) {
             // Support sort on document save
@@ -83,9 +83,9 @@ export class SortInterfaceExtension {
             });
           }
 
+          // TODO: Update message
           window.showInformationMessage(
-            `Successfully sorted ${sortedInterface.length} interface${
-              sortedInterface.length > 1 ? "s" : ""
+            `Successfully sorted ${sortedInterface.length} interface${sortedInterface.length > 1 ? "s" : ""
             }`
           );
         } else {

--- a/src/sort-interface-extension.ts
+++ b/src/sort-interface-extension.ts
@@ -50,13 +50,13 @@ export class SortInterfaceExtension {
         );
 
         if (nodes.length > 0 && sourceFile) {
-          const sortedInterface = this.sorter.sortGenericTypeElements(nodes);
+          const sortedTypesWithElements = this.sorter.sortGenericTypeElements(nodes);
 
           if (event) {
             // Support sort on document save
           } else {
             window.activeTextEditor.edit((editorBuilder: TextEditorEdit) => {
-              sortedInterface.forEach((i) => {
+              sortedTypesWithElements.forEach((i) => {
                 editorBuilder.replace(
                   new Range(
                     this.getPosition(i.rangeToRemove.pos, sourceFile),
@@ -67,11 +67,10 @@ export class SortInterfaceExtension {
               });
             });
           }
+          const sortTypes = this.configurator.getValue("sortTypes") as boolean;
 
-          // TODO: Update message
           window.showInformationMessage(
-            `Successfully sorted ${sortedInterface.length} interface${sortedInterface.length > 1 ? "s" : ""
-            }`
+            `Successfully sorted ${sortedTypesWithElements.length} interface${sortTypes ? ' or type' : ''}.`
           );
         } else {
           window.showWarningMessage(

--- a/src/test/components/extension-test.ts
+++ b/src/test/components/extension-test.ts
@@ -1,0 +1,36 @@
+/* eslint-disable */
+/** Test file to be used when running extension locally in dev. */
+
+interface IInteface1 {
+  /**
+   * Some jsDoc to describe the property
+   */
+  name: string;
+
+  /** One liner of the jsDoc */
+  length: number;
+}
+
+type CustomType = {
+  /**
+   * Some jsDoc to describe the property
+   */
+  name: string;
+
+  /** One liner of the jsDoc */
+  length: number;
+}
+
+interface IInterface {
+  requiredProp1: string;
+  optionalProp1?: string;
+  RequiredProp2: string;
+  OptionalProp2?: string;
+}
+
+type CustomType2 = {
+  requiredProp1: string;
+  optionalProp1?: string;
+  RequiredProp2: string;
+  OptionalProp2?: string;
+}

--- a/src/test/components/parser.test.ts
+++ b/src/test/components/parser.test.ts
@@ -1,3 +1,4 @@
+import { defaultConfig, SimpleConfigurator } from "../../components/configurator";
 import { SimpleTsParser } from "../../components/parser";
 
 import {
@@ -12,45 +13,66 @@ import {
 } from "./test-cases";
 
 describe("Parser", () => {
-  const parser = new SimpleTsParser();
-  const filePath = "Untitled-1";
-  describe("parse number of interface", () => {
-    test("should parse no interface", () => {
-      const { nodes } = parser.parseTypeNodes(filePath, tcClassImplementInterface);
+  describe('default setting', () => {
+    const parser = new SimpleTsParser(new SimpleConfigurator({ default: defaultConfig }));
+    const filePath = "Untitled-1";
+    describe("parse number of interface", () => {
+      test("should parse no interface", () => {
+        const { nodes } = parser.parseTypeNodes(filePath, tcClassImplementInterface);
 
-      expect(nodes.length).toBe(0);
+        expect(nodes.length).toBe(0);
+      });
+
+      test("should parse one interface with input of empty interface", () => {
+        const { nodes } = parser.parseTypeNodes(filePath, tcEmptyInterface);
+        expect(nodes.length).toBe(1);
+      });
+
+      test("should parse one interface with export prefix", () => {
+        const { nodes } = parser.parseTypeNodes(
+          filePath,
+          tcPrefixExport + tcInterfaceWithOneProperty
+        );
+        expect(nodes.length).toBe(1);
+      });
+
+      test("should parse two interfaces with one extends the other", () => {
+        const { nodes } = parser.parseTypeNodes(filePath, tcInterfaceWithExtends);
+        expect(nodes.length).toBe(2);
+      });
+
+      test("should parse one interface with comments", () => {
+        const { nodes } = parser.parseTypeNodes(filePath, tcInterfaceWithComment);
+        expect(nodes.length).toBe(1);
+      });
     });
 
-    test("should parse one interface with input of empty interface", () => {
-      const { nodes } = parser.parseTypeNodes(filePath, tcEmptyInterface);
-      expect(nodes.length).toBe(1);
-    });
-
-    test("should parse one interface with export prefix", () => {
-      const { nodes } = parser.parseTypeNodes(
-        filePath,
-        tcPrefixExport + tcInterfaceWithOneProperty
-      );
-      expect(nodes.length).toBe(1);
-    });
-
-    test("should parse two interfaces with one extends the other", () => {
-      const { nodes } = parser.parseTypeNodes(filePath, tcInterfaceWithExtends);
-      expect(nodes.length).toBe(2);
-    });
-
-    test("should parse one interface with comments", () => {
-      const { nodes } = parser.parseTypeNodes(filePath, tcInterfaceWithComment);
-      expect(nodes.length).toBe(1);
+    describe('parse number of types', () => {
+      test.each(tcPrefixes)("test - %s", (prefix) => {
+        const { nodes } = parser.parseTypeNodes(filePath, prefix + typeWithJsDocProperty);
+        expect(nodes.length).toBe(1);
+        expect(nodes[0].members[0].text).toEqual('name: string;');
+        expect(nodes[0].members[1].text).toEqual('length: number;');
+      });
     });
   });
 
-  describe('parse number of types', () => {
-    test.each(tcPrefixes)("test - %s", (prefix) => {
-      const { nodes } = parser.parseTypeNodes(filePath, prefix + typeWithJsDocProperty);
+  describe('when sortTypes=false', () => {
+    const parser = new SimpleTsParser(
+      new SimpleConfigurator({
+        default: {
+          ...defaultConfig,
+          sortTypes: false
+        },
+      }));
+    const filePath = "Untitled-1";
+    test('should not parse type', () => {
+      const { nodes } = parser.parseTypeNodes(filePath, `export type CustomType = ` + typeWithJsDocProperty);
+      expect(nodes.length).toBe(0);
+    });
+    test('should parse interface', () => {
+      const { nodes } = parser.parseTypeNodes(filePath, `export interface IInterface` + typeWithJsDocProperty);
       expect(nodes.length).toBe(1);
-      expect(nodes[0].members[0].text).toEqual('name: string;');
-      expect(nodes[0].members[1].text).toEqual('length: number;');
     });
   });
 });

--- a/src/test/components/parser.test.ts
+++ b/src/test/components/parser.test.ts
@@ -7,7 +7,8 @@ import {
   tcInterfaceWithOneProperty,
   tcInterfaceWithExtends,
   tcInterfaceWithComment,
-  tcTypeWithJsDocProperty
+  typeWithJsDocProperty,
+  tcPrefixes
 } from "./test-cases";
 
 describe("Parser", () => {
@@ -45,8 +46,8 @@ describe("Parser", () => {
   });
 
   describe('parse number of types', () => {
-    test("test", () => {
-      const { nodes } = parser.parseTypeNodes(filePath, tcTypeWithJsDocProperty);
+    test.each(tcPrefixes)("test - %s", (prefix) => {
+      const { nodes } = parser.parseTypeNodes(filePath, prefix + typeWithJsDocProperty);
       expect(nodes.length).toBe(1);
       expect(nodes[0].members[0].text).toEqual('name: string;');
       expect(nodes[0].members[1].text).toEqual('length: number;');

--- a/src/test/components/parser.test.ts
+++ b/src/test/components/parser.test.ts
@@ -6,7 +6,8 @@ import {
   tcPrefixExport,
   tcInterfaceWithOneProperty,
   tcInterfaceWithExtends,
-  tcInterfaceWithComment
+  tcInterfaceWithComment,
+  tcTypeWithJsDocProperty
 } from "./test-cases";
 
 describe("Parser", () => {
@@ -14,18 +15,18 @@ describe("Parser", () => {
   const filePath = "Untitled-1";
   describe("parse number of interface", () => {
     test("should parse no interface", () => {
-      const { nodes } = parser.parseInterface(filePath, tcClassImplementInterface);
-      
+      const { nodes } = parser.parseTypeNodes(filePath, tcClassImplementInterface);
+
       expect(nodes.length).toBe(0);
     });
 
     test("should parse one interface with input of empty interface", () => {
-      const { nodes } = parser.parseInterface(filePath, tcEmptyInterface);
+      const { nodes } = parser.parseTypeNodes(filePath, tcEmptyInterface);
       expect(nodes.length).toBe(1);
     });
 
     test("should parse one interface with export prefix", () => {
-      const { nodes } = parser.parseInterface(
+      const { nodes } = parser.parseTypeNodes(
         filePath,
         tcPrefixExport + tcInterfaceWithOneProperty
       );
@@ -33,13 +34,22 @@ describe("Parser", () => {
     });
 
     test("should parse two interfaces with one extends the other", () => {
-      const { nodes } = parser.parseInterface(filePath, tcInterfaceWithExtends);
+      const { nodes } = parser.parseTypeNodes(filePath, tcInterfaceWithExtends);
       expect(nodes.length).toBe(2);
     });
 
     test("should parse one interface with comments", () => {
-      const { nodes } = parser.parseInterface(filePath, tcInterfaceWithComment);
+      const { nodes } = parser.parseTypeNodes(filePath, tcInterfaceWithComment);
       expect(nodes.length).toBe(1);
+    });
+  });
+
+  describe('parse number of types', () => {
+    test("test", () => {
+      const { nodes } = parser.parseTypeNodes(filePath, tcTypeWithJsDocProperty);
+      expect(nodes.length).toBe(1);
+      expect(nodes[0].members[0].text).toEqual('name: string;');
+      expect(nodes[0].members[1].text).toEqual('length: number;');
     });
   });
 });

--- a/src/test/components/sorter.test.ts
+++ b/src/test/components/sorter.test.ts
@@ -34,28 +34,28 @@ describe("Sorter", () => {
   const filePath = "Untitled-1";
 
   test("should not break with no interface", () => {
-    const { nodes } = parser.parseInterface(
+    const { nodes } = parser.parseTypeNodes(
       filePath,
       tcClassImplementInterface
     );
-    const sorted = sorter.sortInterfaceElements(nodes);
+    const sorted = sorter.sortGenericTypeElements(nodes);
 
     expect(sorted.length).toBe(0);
   });
 
   test("should not sort with empty interface", () => {
-    const { nodes } = parser.parseInterface(filePath, tcEmptyInterface);
-    const sorted = sorter.sortInterfaceElements(nodes);
+    const { nodes } = parser.parseTypeNodes(filePath, tcEmptyInterface);
+    const sorted = sorter.sortGenericTypeElements(nodes);
 
     expect(sorted.length).toBe(0);
   });
 
   test("should sort one interface with export prefix", () => {
-    const { nodes } = parser.parseInterface(
+    const { nodes } = parser.parseTypeNodes(
       filePath,
       tcPrefixExport + tcInterfaceWithOneProperty
     );
-    const sorted = sorter.sortInterfaceElements(nodes);
+    const sorted = sorter.sortGenericTypeElements(nodes);
 
     expect(sorted.length).toBe(1);
     expect(sorted[0].rangeToRemove).toEqual({ pos: 30, end: 46 });
@@ -63,8 +63,8 @@ describe("Sorter", () => {
 
   test("should sort two interfaces with one extends the other", () => {
     const textIntput = tcInterfaceWithExtends;
-    const { nodes } = parser.parseInterface(filePath, textIntput);
-    const sorted = sorter.sortInterfaceElements(nodes);
+    const { nodes } = parser.parseTypeNodes(filePath, textIntput);
+    const sorted = sorter.sortGenericTypeElements(nodes);
 
     expect(sorted.length).toBe(1);
     expect(sorted[0].rangeToRemove).toEqual({ pos: 75, end: 110 });
@@ -75,8 +75,8 @@ describe("Sorter", () => {
 
   test("should sort one interface with comments", () => {
     const textIntput = tcInterfaceWithJsDocProperty;
-    const { nodes } = parser.parseInterface(filePath, textIntput);
-    const sorted = sorter.sortInterfaceElements(nodes);
+    const { nodes } = parser.parseTypeNodes(filePath, textIntput);
+    const sorted = sorter.sortGenericTypeElements(nodes);
 
     expect(sorted.length).toBe(1);
     expect(sorted[0].rangeToRemove).toEqual({ pos: 23, end: 143 });
@@ -93,8 +93,8 @@ describe("Sorter", () => {
     );
 
     const textIntput = tcInterfaceWithCapitalLetter;
-    const { nodes } = parser.parseInterface(filePath, textIntput);
-    const sorted = sorter2.sortInterfaceElements(nodes);
+    const { nodes } = parser.parseTypeNodes(filePath, textIntput);
+    const sorted = sorter2.sortGenericTypeElements(nodes);
 
     expect(sorted.length).toBe(1);
     expect(sorted[0].rangeToRemove).toEqual({ pos: 23, end: 82 });
@@ -111,8 +111,8 @@ describe("Sorter", () => {
     );
 
     const textIntput = tcInterfaceWithCapitalLetter;
-    const { nodes } = parser.parseInterface(filePath, textIntput);
-    const sorted = sorter2.sortInterfaceElements(nodes);
+    const { nodes } = parser.parseTypeNodes(filePath, textIntput);
+    const sorted = sorter2.sortGenericTypeElements(nodes);
 
     expect(sorted.length).toBe(1);
     expect(sorted[0].rangeToRemove).toEqual({ pos: 23, end: 82 });
@@ -134,8 +134,8 @@ describe("Sorter", () => {
       );
 
       const textIntput = tcInterfaceWithOptionalProperty;
-      const { nodes } = parser.parseInterface(filePath, textIntput);
-      const sorted = sorter2.sortInterfaceElements(nodes);
+      const { nodes } = parser.parseTypeNodes(filePath, textIntput);
+      const sorted = sorter2.sortGenericTypeElements(nodes);
 
       expect(sorted.length).toBe(1);
       expect(sorted[0].rangeToRemove).toEqual({ pos: 23, end: 73 });
@@ -156,8 +156,8 @@ describe("Sorter", () => {
       );
 
       const textIntput = tcInterfaceWithMultipleOptionalProperty;
-      const { nodes } = parser.parseInterface(filePath, textIntput);
-      const sorted = sorter2.sortInterfaceElements(nodes);
+      const { nodes } = parser.parseTypeNodes(filePath, textIntput);
+      const sorted = sorter2.sortGenericTypeElements(nodes);
 
       expect(sorted.length).toBe(1);
       expect(sorted[0].rangeToRemove).toEqual({ pos: 23, end: 125 });
@@ -178,8 +178,8 @@ describe("Sorter", () => {
       );
 
       const textIntput = tcInterfaceWithMultipleOptionalProperty;
-      const { nodes } = parser.parseInterface(filePath, textIntput);
-      const sorted = sorter2.sortInterfaceElements(nodes);
+      const { nodes } = parser.parseTypeNodes(filePath, textIntput);
+      const sorted = sorter2.sortGenericTypeElements(nodes);
 
       expect(sorted.length).toBe(1);
       expect(sorted[0].rangeToRemove).toEqual({ pos: 23, end: 125 });

--- a/src/test/components/sorter.test.ts
+++ b/src/test/components/sorter.test.ts
@@ -1,6 +1,7 @@
 import { SimpleTsParser } from "../../components/parser";
 import { SimpleTsSorter } from "../../components/sorter";
 import {
+  defaultConfig,
   IInterfaceSorterConfiguration,
   SimpleConfigurator,
 } from "../../components/configurator";
@@ -19,14 +20,8 @@ import {
 } from "./test-cases";
 
 describe("Sorter", () => {
-  const defaultConfig: IInterfaceSorterConfiguration = {
-    lineBetweenMembers: true,
-    indentSpace: 2,
-    sortByCapitalLetterFirst: false,
-    sortByRequiredElementFirst: false,
-  };
 
-  const parser = new SimpleTsParser();
+  const parser = new SimpleTsParser(new SimpleConfigurator({ default: defaultConfig }));
   const sorter = new SimpleTsSorter(
     new SimpleConfigurator({ default: defaultConfig })
   );

--- a/src/test/components/sorter.test.ts
+++ b/src/test/components/sorter.test.ts
@@ -6,16 +6,16 @@ import {
 } from "../../components/configurator";
 
 import {
+  tcPrefixes,
   tcClassImplementInterface,
   tcEmptyInterface,
   tcPrefixExport,
-  tcInterfaceWithOneProperty,
   tcInterfaceWithExtends,
-  tcInterfaceWithComment,
-  tcInterfaceWithJsDocProperty,
   tcInterfaceWithOptionalProperty,
   tcInterfaceWithCapitalLetter,
   tcInterfaceWithMultipleOptionalProperty,
+  typeWithJsDocProperty,
+  typeWithOneProperty,
 } from "./test-cases";
 
 describe("Sorter", () => {
@@ -50,15 +50,18 @@ describe("Sorter", () => {
     expect(sorted.length).toBe(0);
   });
 
-  test("should sort one interface with export prefix", () => {
+  test.each([tcPrefixes])("should sort one with export prefix - %s", (prefix) => {
+    const prefixLength = prefix.length;
+    const exportLength = tcPrefixExport.length;
     const { nodes } = parser.parseTypeNodes(
       filePath,
-      tcPrefixExport + tcInterfaceWithOneProperty
+      tcPrefixExport + prefix + typeWithOneProperty
     );
     const sorted = sorter.sortGenericTypeElements(nodes);
 
     expect(sorted.length).toBe(1);
-    expect(sorted[0].rangeToRemove).toEqual({ pos: 30, end: 46 });
+    //  
+    expect(sorted[0].rangeToRemove).toEqual({ pos: prefixLength + exportLength + 1, end: prefixLength + exportLength + 17 });
   });
 
   test("should sort two interfaces with one extends the other", () => {
@@ -73,15 +76,16 @@ describe("Sorter", () => {
     );
   });
 
-  test("should sort one interface with comments", () => {
-    const textIntput = tcInterfaceWithJsDocProperty;
+  test.each(tcPrefixes)(`should sort one type with comments - %s`, (prefix) => {
+    const prefixLength = prefix.length;
+    const textIntput = prefix + typeWithJsDocProperty;
     const { nodes } = parser.parseTypeNodes(filePath, textIntput);
     const sorted = sorter.sortGenericTypeElements(nodes);
 
     expect(sorted.length).toBe(1);
-    expect(sorted[0].rangeToRemove).toEqual({ pos: 23, end: 143 });
+    expect(sorted[0].rangeToRemove).toEqual({ pos: prefixLength + 1, end: prefixLength + 121 });
     expect(sorted[0].textToReplace).toEqual(
-      textIntput.substring(93, 143) + "\n" + textIntput.substring(23, 92)
+      textIntput.substring(prefixLength + 71, prefixLength + 121) + "\n" + textIntput.substring(prefixLength + 1, prefixLength + 70)
     );
   });
 

--- a/src/test/components/test-cases.ts
+++ b/src/test/components/test-cases.ts
@@ -1,11 +1,21 @@
+export const tcPrefixes = ['interface IInterface ', 'type CustomType '];
+
 export const tcEmptyInterface = `
 interface IInterface {} 
 `;
 
 export const tcPrefixExport = `export `;
 
+export const typeWithOneProperty = `{
+  name: string;
+}`;
+
 export const tcInterfaceWithOneProperty = `
-interface IInterface {
+interface IInterface 
+`;
+
+export const tcTypeWithOneProperty = `
+type CustomType {
   name: string;
 }
 `;
@@ -40,20 +50,11 @@ export const tcInterfaceWithComment = `
 ${constJsDocComments}
 ${tcInterfaceWithOneProperty}`;
 
-export const tcInterfaceWithJsDocProperty = `
-interface IInterface {
-  /**
-   * Some jsDoc to describe the property
-   */
-  name: string;
-
-  /** One liner of the jsDoc */
-  length: number;
-}
-`;
-
-export const tcTypeWithJsDocProperty = `
-type CustomType {
+/**
+ * member 1: 1-71
+ * member 2: 72 - 121
+ */
+export const typeWithJsDocProperty = `{
   /**
    * Some jsDoc to describe the property
    */

--- a/src/test/components/test-cases.ts
+++ b/src/test/components/test-cases.ts
@@ -52,6 +52,18 @@ interface IInterface {
 }
 `;
 
+export const tcTypeWithJsDocProperty = `
+type CustomType {
+  /**
+   * Some jsDoc to describe the property
+   */
+  name: string;
+
+  /** One liner of the jsDoc */
+  length: number;
+}
+`;
+
 export const tcInterfaceWithOptionalProperty = `
 interface IInterface {
   requiredProp: string;

--- a/src/test/components/test-cases.ts
+++ b/src/test/components/test-cases.ts
@@ -1,4 +1,4 @@
-export const tcPrefixes = ['interface IInterface ', 'type CustomType '];
+export const tcPrefixes = ['interface IInterface ', 'type CustomType = '];
 
 export const tcEmptyInterface = `
 interface IInterface {} 
@@ -15,7 +15,7 @@ interface IInterface
 `;
 
 export const tcTypeWithOneProperty = `
-type CustomType {
+type CustomType = {
   name: string;
 }
 `;


### PR DESCRIPTION
Support sorting `type`, e.g. 

```
type CustomType {
  /**
   * Some jsDoc to describe the property
   */
  name: string;

  /** One liner of the jsDoc */
  length: number;
}
```

Todos:
- [x] Optionally support `type` via settings, `tsInterfaceSorter.sortTypes`
- [x] `parser` to support `type`, more tests!
- [x] `sorter` to support `type`
- [x] User friendly features, e.g. message update to include not only just "interface"
- [x] Release prep, e.g. new readme

Closes #13