### PR TITLE
Add TypeScript resolution with workspace and tsdk support

### DIFF
--- a/package.json
+++ b/package.json
@@ -74,6 +74,11 @@
           "type": "boolean",
           "default": true,
           "description": "When on, sort `type` as well as `interface`."
+        },
+        "tsInterfaceSorter.useWorkspaceTypeScript": {
+          "type": "boolean",
+          "default": false,
+          "description": "When enabled, uses the TypeScript version from the workspace or the version selected in VS Code ('TypeScript: Select TypeScript Version'), instead of the bundled version. This allows parsing newer TypeScript syntax supported by your project's TypeScript version."
         }
       }
     }

--- a/src/components/parser.ts
+++ b/src/components/parser.ts
@@ -1,5 +1,6 @@
 import * as fs from "fs";
 import * as ts from "typescript";
+import type { TypeScriptApi } from "../typescript-provider";
 import { defaultConfig, IConfigurator, IInterfaceSorterConfiguration, SimpleConfigurator } from "./configurator";
 
 export interface IComment {
@@ -47,11 +48,14 @@ export interface ITsParser {
 
 export class SimpleTsParser implements ITsParser {
   private configurator: IConfigurator<IInterfaceSorterConfiguration>;
+  private tsApi: TypeScriptApi;
 
   public constructor(
-    configurator: IConfigurator<IInterfaceSorterConfiguration>
+    configurator: IConfigurator<IInterfaceSorterConfiguration>,
+    tsApi?: TypeScriptApi
   ) {
     this.configurator = configurator;
+    this.tsApi = tsApi || ts;
   }
 
   public parseTypeNodes(
@@ -70,7 +74,7 @@ export class SimpleTsParser implements ITsParser {
   }
 
   private createSourceFile(fullFilePath: string, sourceText: string): ts.SourceFile {
-    return ts.createSourceFile(fullFilePath, sourceText, ts.ScriptTarget.ES2016, false);
+    return this.tsApi.createSourceFile(fullFilePath, sourceText, this.tsApi.ScriptTarget.ES2016, false);
   }
 
   private delintFile(
@@ -129,7 +133,7 @@ export class SimpleTsParser implements ITsParser {
         break;
     }
 
-    ts.forEachChild(node, node => {
+    this.tsApi.forEachChild(node, node => {
       typeNodes.push(...this.delintTypeNodes(node, sourceFile, sourceFileText));
     });
 
@@ -138,9 +142,9 @@ export class SimpleTsParser implements ITsParser {
 
   private getComments(node: ts.Node, sourceFileText: string): IComments {
     const leadingComment = (
-      ts.getLeadingCommentRanges(sourceFileText, node.getFullStart()) || []
+      this.tsApi.getLeadingCommentRanges(sourceFileText, node.getFullStart()) || []
     ).map(range => this.getComment(range, sourceFileText));
-    const trailingComment = (ts.getTrailingCommentRanges(sourceFileText, node.getEnd()) || []).map(
+    const trailingComment = (this.tsApi.getTrailingCommentRanges(sourceFileText, node.getEnd()) || []).map(
       range => this.getComment(range, sourceFileText)
     );
     return { leadingComment, trailingComment };

--- a/src/sort-interface-extension.ts
+++ b/src/sort-interface-extension.ts
@@ -1,4 +1,4 @@
-import * as ts from "typescript";
+import type * as ts from "typescript";
 import {
   TextDocumentChangeEvent,
   window,
@@ -18,6 +18,7 @@ import {
   IInterfaceSorterConfiguration,
   defaultConfig,
 } from "./components/configurator";
+import { resolveTypeScript, TypeScriptApi } from "./typescript-provider";
 
 const EXTENSION_IDENTIFIER = "tsInterfaceSorter";
 
@@ -29,6 +30,7 @@ export class SortInterfaceExtension {
     new SimpleConfigurator(this.config);
   private parser: ITsParser = new SimpleTsParser(this.configurator);
   private sorter: ITsSorter = new SimpleTsSorter(this.configurator);
+  private resolvedTypeScriptVersion: string | undefined;
 
   public updateFromWorkspaceConfig() {
     const fullConfig = workspace.getConfiguration(EXTENSION_IDENTIFIER);
@@ -38,6 +40,34 @@ export class SortInterfaceExtension {
       ...(fullConfig as any),
       indentSpace: editorConfig.tabSize,
     });
+
+    // Resolve TypeScript version based on user setting
+    const tsApi = this.resolveTypeScriptApi(fullConfig);
+    this.parser = new SimpleTsParser(this.configurator, tsApi);
+  }
+
+  private resolveTypeScriptApi(
+    fullConfig: ReturnType<typeof workspace.getConfiguration>
+  ): TypeScriptApi | undefined {
+    const useWorkspaceTs = fullConfig.get<boolean>(
+      "useWorkspaceTypeScript",
+      false
+    );
+    if (!useWorkspaceTs) {
+      this.resolvedTypeScriptVersion = undefined;
+      return undefined; // use bundled (default)
+    }
+
+    const tsdk = workspace.getConfiguration("typescript").get<string>("tsdk");
+    const workspacePaths = (workspace.workspaceFolders || []).map(
+      (f) => f.uri.fsPath
+    );
+    const resolved = resolveTypeScript(tsdk, workspacePaths);
+    this.resolvedTypeScriptVersion =
+      resolved.resolvedFrom !== "bundled"
+        ? `${resolved.version} (${resolved.resolvedFrom})`
+        : undefined;
+    return resolved.tsModule;
   }
 
   public sortActiveWindowInterfaceMembers(event?: TextDocumentChangeEvent) {
@@ -73,10 +103,13 @@ export class SortInterfaceExtension {
           }
           const sortTypes = this.configurator.getValue("sortTypes") as boolean;
 
+          const tsVersionInfo = this.resolvedTypeScriptVersion
+            ? ` (using TypeScript ${this.resolvedTypeScriptVersion})`
+            : "";
           window.showInformationMessage(
             `Successfully sorted ${sortedTypesWithElements.length} interface${
               sortTypes ? " or type" : ""
-            }.`
+            }.${tsVersionInfo}`
           );
         } else {
           window.showWarningMessage(

--- a/src/test/components/typescript-provider.test.ts
+++ b/src/test/components/typescript-provider.test.ts
@@ -1,0 +1,96 @@
+import * as path from "path";
+import { resolveTypeScript, getBundledTypeScript } from "../../typescript-provider";
+import { SimpleTsParser } from "../../components/parser";
+import { SimpleConfigurator, defaultConfig } from "../../components/configurator";
+
+describe("TypeScriptProvider", () => {
+  describe("getBundledTypeScript", () => {
+    test("should return bundled TypeScript module", () => {
+      const result = getBundledTypeScript();
+
+      expect(result.tsModule).toBeDefined();
+      expect(typeof result.tsModule.createSourceFile).toBe("function");
+      expect(typeof result.version).toBe("string");
+      expect(result.resolvedFrom).toBe("bundled");
+    });
+  });
+
+  describe("resolveTypeScript", () => {
+    test("should return bundled TypeScript when no tsdk and no workspace paths", () => {
+      const result = resolveTypeScript(undefined, []);
+
+      expect(result.resolvedFrom).toBe("bundled");
+      expect(typeof result.tsModule.createSourceFile).toBe("function");
+    });
+
+    test("should return bundled TypeScript when workspace path has no node_modules/typescript", () => {
+      const result = resolveTypeScript(undefined, ["/nonexistent/path"]);
+
+      expect(result.resolvedFrom).toBe("bundled");
+    });
+
+    test("should resolve from workspace node_modules when typescript is present", () => {
+      // Use the actual project's node_modules as a workspace path
+      const projectRoot = path.resolve(__dirname, "..", "..", "..");
+      const result = resolveTypeScript(undefined, [projectRoot]);
+
+      expect(result.resolvedFrom).toBe("workspace");
+      expect(typeof result.tsModule.createSourceFile).toBe("function");
+      expect(typeof result.version).toBe("string");
+    });
+
+    test("should resolve from tsdk when valid path is provided", () => {
+      // Point tsdk to the actual TypeScript lib directory
+      const projectRoot = path.resolve(__dirname, "..", "..", "..");
+      const tsdkPath = path.join(projectRoot, "node_modules", "typescript", "lib");
+      const result = resolveTypeScript(tsdkPath, []);
+
+      expect(result.resolvedFrom).toBe("tsdk");
+      expect(typeof result.tsModule.createSourceFile).toBe("function");
+    });
+
+    test("should resolve from relative tsdk path", () => {
+      const projectRoot = path.resolve(__dirname, "..", "..", "..");
+      const result = resolveTypeScript("node_modules/typescript/lib", [projectRoot]);
+
+      expect(result.resolvedFrom).toBe("tsdk");
+      expect(typeof result.tsModule.createSourceFile).toBe("function");
+    });
+
+    test("should fall back to workspace when tsdk path is invalid", () => {
+      const projectRoot = path.resolve(__dirname, "..", "..", "..");
+      const result = resolveTypeScript("/invalid/tsdk/path", [projectRoot]);
+
+      expect(result.resolvedFrom).toBe("workspace");
+    });
+
+    test("should prioritize tsdk over workspace", () => {
+      const projectRoot = path.resolve(__dirname, "..", "..", "..");
+      const tsdkPath = path.join(projectRoot, "node_modules", "typescript", "lib");
+      const result = resolveTypeScript(tsdkPath, [projectRoot]);
+
+      // tsdk should take priority
+      expect(result.resolvedFrom).toBe("tsdk");
+    });
+  });
+
+  describe("parser integration with resolved TypeScript", () => {
+    test("should parse interfaces using resolved TypeScript module", () => {
+      const resolved = getBundledTypeScript();
+      const parser = new SimpleTsParser(
+        new SimpleConfigurator({ default: defaultConfig }),
+        resolved.tsModule
+      );
+
+      const { nodes } = parser.parseTypeNodes("test.ts", `
+interface ITest {
+  name: string;
+  age: number;
+}
+      `);
+
+      expect(nodes.length).toBe(1);
+      expect(nodes[0].members.length).toBe(2);
+    });
+  });
+});

--- a/src/typescript-provider.ts
+++ b/src/typescript-provider.ts
@@ -1,0 +1,90 @@
+import * as path from "path";
+
+/**
+ * The TypeScript compiler API module type.
+ */
+export type TypeScriptApi = typeof import("typescript");
+
+export interface TypeScriptResolution {
+  tsModule: TypeScriptApi;
+  version: string;
+  resolvedFrom: string;
+}
+
+/**
+ * Resolves the TypeScript module to use at runtime.
+ *
+ * Priority:
+ * 1. Path from `typescript.tsdk` VS Code setting (user's selected TS version)
+ * 2. Workspace `node_modules/typescript`
+ * 3. Bundled TypeScript (fallback)
+ */
+export function resolveTypeScript(
+  tsdk: string | undefined,
+  workspacePaths: string[]
+): TypeScriptResolution {
+  // 1. Try typescript.tsdk setting
+  if (tsdk) {
+    const result = tryResolveTsdk(tsdk, workspacePaths);
+    if (result) {
+      return result;
+    }
+  }
+
+  // 2. Try workspace node_modules
+  for (const wsPath of workspacePaths) {
+    const result = tryRequireTs(
+      path.join(wsPath, "node_modules", "typescript"),
+      "workspace"
+    );
+    if (result) {
+      return result;
+    }
+  }
+
+  // 3. Bundled fallback
+  return getBundledTypeScript();
+}
+
+export function getBundledTypeScript(): TypeScriptResolution {
+  const ts = require("typescript");
+  return { tsModule: ts, version: ts.version, resolvedFrom: "bundled" };
+}
+
+function tryResolveTsdk(
+  tsdk: string,
+  workspacePaths: string[]
+): TypeScriptResolution | null {
+  const pathsToTry = path.isAbsolute(tsdk)
+    ? [tsdk]
+    : workspacePaths.map((ws) => path.resolve(ws, tsdk));
+
+  for (const tsdkPath of pathsToTry) {
+    // tsdk points to TypeScript's lib directory, go up to package root
+    const tsPackagePath = path.resolve(tsdkPath, "..");
+    const result = tryRequireTs(tsPackagePath, "tsdk");
+    if (result) {
+      return result;
+    }
+  }
+  return null;
+}
+
+function tryRequireTs(
+  tsPath: string,
+  source: string
+): TypeScriptResolution | null {
+  try {
+    const tsModule = require(tsPath);
+    if (
+      tsModule &&
+      typeof tsModule.version === "string" &&
+      typeof tsModule.createSourceFile === "function"
+    ) {
+      return { tsModule, version: tsModule.version, resolvedFrom: source };
+    }
+  } catch {
+    // Module not found or invalid
+  }
+  return null;
+}


### PR DESCRIPTION
## Summary
This PR adds intelligent TypeScript module resolution to the extension, allowing users to choose between using the bundled TypeScript version or their workspace's TypeScript version. This enables the extension to parse TypeScript syntax supported by the user's project version.

Fixes #8

## Key Changes
- **New TypeScript Provider Module** (`src/typescript-provider.ts`): Implements a resolution strategy with three priority levels:
  1. User-configured `typescript.tsdk` setting (explicit TS version selection)
  2. Workspace `node_modules/typescript` (project's installed version)
  3. Bundled TypeScript (fallback)

- **Parser Enhancement**: Modified `SimpleTsParser` to accept an optional `TypeScriptApi` parameter, allowing it to use different TypeScript versions at runtime instead of always using the bundled version

- **Extension Configuration**: 
  - Added new setting `tsInterfaceSorter.useWorkspaceTypeScript` to control whether to use workspace/selected TypeScript
  - Updated `SortInterfaceExtension` to resolve and inject the appropriate TypeScript API into the parser
  - Enhanced user feedback to show which TypeScript version is being used

- **Comprehensive Test Coverage**: Added `typescript-provider.test.ts` with tests covering all resolution paths and fallback scenarios

## Implementation Details
- The resolution logic gracefully falls back to bundled TypeScript if workspace or tsdk paths are invalid
- Relative tsdk paths are resolved relative to workspace folders
- The parser maintains backward compatibility by defaulting to bundled TypeScript when no API is provided
- TypeScript module validation checks for required methods (`createSourceFile`) and properties (`version`) before accepting a module

https://claude.ai/code/session_014rEQfKdvPN9YXH4C3ftBo4